### PR TITLE
Add grid

### DIFF
--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -19,13 +19,17 @@ private:
 public:
   fluid_grid(int pixels_x, int pixels_y)
       : pixels_x(pixels_x), pixels_y(pixels_y) {
-    size_x = pixels_x / cell_size - 1; // -1 for boundary condition.
-    size_y = pixels_y / cell_size - 1;
+    size_x = pixels_x / cell_size;
+    size_y = pixels_y / cell_size;
     size = (pixels_x + 2) * (pixels_y + 2);
 
-    std::vector<int> grid(size);
+    grid.resize(size);
   }
-  int address(int x, int y) {
-    // return ( ((i)+(N+2)*(j)))
+
+  // using getters and setters so that only grid has access to the underlying
+  // vector.
+  int get(int x, int y) { return grid[(((x) + (pixels_y + 2) * (y)))]; }
+  void set(int x, int y, int set) {
+    grid[(((x) + (pixels_y + 2) * (y)))] = set;
   }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "event_manager.hpp"
+#include "grid.hpp"
 #include "gui.hpp"
 #include <array>
 
@@ -8,7 +9,7 @@
 #define IX(i, j) ((i) + (N + 2) * (j))
 
 // Define grid size
-constexpr int N = 100;
+constexpr int N = 5;
 constexpr int SIZE = (N + 2) * (N + 2);
 
 /*
@@ -59,6 +60,24 @@ int main() {
   */
 
   gui fluid_gui;
+
+  fluid_grid grid(N, N);
+
+  // DELETE from here
+  // Showing how the grid works.
+  auto a = grid.get(
+      2, 5); // notice that 'a' will not change after setting (2,5) to 10. We're
+             // using the val instead of reference for safety
+  grid.set(2, 5, 10);
+  grid.set(6, 6, 1);
+  auto b = grid.get(2, 5);
+  for (int i = 0; i < 7; ++i) { // print whole grid.
+    for (int j = 0; j < 7; ++j) {
+      std::cout << grid.get(i, j) << " ";
+    }
+    std::cout << std::endl;
+  }
+  // DELETE to here
 
   // Create an event manager and pass the GUI window to its constructor
   event_manager my_event_manager(fluid_gui);


### PR DESCRIPTION
- N-dimensional grid
- Choose how many pixels should make up a cell (currently set to 1-to-1) (A bit dodgy since It gets distorted when the cells don't divide into the pixels evenly).
-  Grid has getters and setters so that we never access the underlying vector. This is exampled in main.

- Main contains examples of how to use the grid and what it looks like.