### PR TITLE
Encapsulate get_current_draw_type()

### DIFF
--- a/headers/const.hpp
+++ b/headers/const.hpp
@@ -7,7 +7,7 @@ using std::size_t;
 using s_size_t = std::make_signed_t<size_t>;
 
 // Unsigned versions of programs base defaults
-constexpr size_t AXIS_SIZE = 150;
+constexpr size_t AXIS_SIZE = 80;
 constexpr size_t BUFFER_SIZE = (AXIS_SIZE + 2) * (AXIS_SIZE + 2);
 constexpr size_t CELL_SIZE = 5;
 

--- a/headers/gui.hpp
+++ b/headers/gui.hpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <string>
 #include <tuple>
+#include <cmath>
 
 using std::size_t;
 
@@ -21,14 +22,13 @@ private:
     const std::string window_text = "Fluid Simulation";
     sf::RenderWindow window;
 
-public:
     enum class draw_type : short { GREY,
-        HSV,
-        VEL };
-
+    HSV,
+    VEL };
     draw_type current_draw_type = draw_type::GREY;
 
-    draw_type get_current_draw_type() const { return current_draw_type; }
+
+public:
     gui()
         : window(sf::VideoMode(screen_width, screen_height), window_text)
     {
@@ -73,10 +73,10 @@ public:
 
         return event;
     }
-    auto update_display(std::array<float, BUFFER_SIZE>& data, draw_type type) -> void
+    auto update_display(std::array<float, BUFFER_SIZE>& data) -> void
     {
         window.clear();
-        switch (type) {
+        switch (current_draw_type) {
         case draw_type::GREY:
             GreyScaleMatrixToSFML(data);
             break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,10 @@ auto main() -> int
         event_mouse_click = my_event_manager.check_left_mouse_button();
 
         if (event_mouse_click != 0) {
-            ds.add_density(10, event_mouse_click);
+            ds.add_density(3, event_mouse_click);
         }
 
-        fluid_gui.update_display(ds.x(), fluid_gui.get_current_draw_type());
+        fluid_gui.update_display(ds.x());
 
         std::this_thread::sleep_for(ms(5));
 


### PR DESCRIPTION
Get current draw type was a public getter that was only being used by gui. I changed it to a private attribute.
@AydinFicker can you check this, I think it should be good as the only class that used get_current_draw_type was the gui class. If this is going to change in future then revoke this pr.