### PR TITLE
Fix input delay (some machines)

### DIFF
--- a/headers/gui.hpp
+++ b/headers/gui.hpp
@@ -43,7 +43,7 @@ public:
     auto check_event() -> sf::Event
     {
         sf::Event event;
-        while (window.pollEvent(event)) {
+        while (window.pollEvent(event)) { // while there are events in the queue
             // Handle the event
             if (event.type == sf::Event::Closed) {
                 window.close();

--- a/headers/gui.hpp
+++ b/headers/gui.hpp
@@ -42,35 +42,28 @@ public:
 
     auto check_event() -> sf::Event
     {
-        sf::Event event {};
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            // Handle the event
+            if (event.type == sf::Event::Closed) {
+                window.close();
+            }
 
-        if (!window.isOpen() || !window.pollEvent(event)) {
-            // Return an empty event if the window is closed or
-            // there are no more events
-            return sf::Event();
-        }
-
-        // not part of event manager since it deals with
-        // the window, not the fluids.
-        if (event.type == sf::Event::Closed) {
-            window.close();
-        }
-
-        if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::C) {
-            // Toggle to the next draw type
-            switch (current_draw_type) {
-            case draw_type::GREY:
-                current_draw_type = draw_type::HSV;
-                break;
-            case draw_type::HSV:
-                current_draw_type = draw_type::VEL;
-                break;
-            case draw_type::VEL:
-                current_draw_type = draw_type::GREY;
-                break;
+            if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::C) {
+                // Toggle to the next draw type
+                switch (current_draw_type) {
+                case draw_type::GREY:
+                    current_draw_type = draw_type::HSV;
+                    break;
+                case draw_type::HSV:
+                    current_draw_type = draw_type::VEL;
+                    break;
+                case draw_type::VEL:
+                    current_draw_type = draw_type::GREY;
+                    break;
+                }
             }
         }
-
         return event;
     }
     auto update_display(std::array<float, BUFFER_SIZE>& data) -> void

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ auto main() -> int
     while (fluid_gui.is_open()) {
 
         // Check for events and handle them
-        [[maybe_unused]] auto event = fluid_gui.check_event();
+        fluid_gui.check_event();
 
         // event_mouse_click = my_event_manager.handle_event(event);
         event_mouse_click = my_event_manager.check_left_mouse_button();


### PR DESCRIPTION
On my machine there was input delay when pressing C and pressing the exit button.
I think that it's something strange with the cpu scheduling algorithm, it's not clearing the event queue quickly.
This pull request forces the queue to be fully dealt with on every iteration, fixing the problem.